### PR TITLE
Fix arm-runner CI issue

### DIFF
--- a/.github/workflows/rasp-runner.yml
+++ b/.github/workflows/rasp-runner.yml
@@ -11,7 +11,14 @@ jobs:
         with:
           base_image: https://dietpi.com/downloads/images/DietPi_RPi-ARMv8-Bullseye.7z
           cpu: cortex-a53
+          bind_mount_repository: true
+          image_additional_mb: 10240
+          optimize_image: false
           commands: |
+            # Rust complains (rightly) that $HOME doesn't match eid home
+            export HOME=/root
+            # Workaround to CI worker being stuck on Updating crates.io index
+            export CARGO_REGISTRIES_CRATES_IO_PROTOCOL=sparse
             apt-get update -y --allow-releaseinfo-change
             apt-get upgrade -y
             apt-get autoremove -y


### PR DESCRIPTION
Add workaround for "Updating crates.io index" issue
Enlarge image to download build files
Bind mount repository as the goal doesn't seem to be to produce an image
Likewise, disable image optimization

Fixes pguyot/arm-runner-action/issues/77